### PR TITLE
bump hugo-bin version to 0.50.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,6 @@
     "npm": ">= 3.10.10"
   },
   "dependencies": {
-    "hugo-bin": "^0.27.0"
+    "hugo-bin": "^0.50.0"
   }
 }


### PR DESCRIPTION
Bump hugo-bin to latest version to address some `npm audit` issues.